### PR TITLE
support authentication method with session token

### DIFF
--- a/app/SimpleDb.js
+++ b/app/SimpleDb.js
@@ -124,7 +124,8 @@ Ext.define('SdbNavigator.SimpleDb', {
 			this.signer = new AWSV2Signer(
 				Ext.getCmp('awsAccessKey').getValue(),
 				Ext.getCmp('awsSecretKey').getValue(),
-				Ext.getCmp('awsStsArn').getValue()
+				Ext.getCmp('awsStsArn').getValue(),
+				Ext.getCmp('awsSessionToken').getValue()
 			);
 		}
 

--- a/app/view/SettingsPanel.js
+++ b/app/view/SettingsPanel.js
@@ -128,6 +128,32 @@ Ext.define('SdbNavigator.view.SettingsPanel', {
 			]
 		},
 		{
+			flex: 1.5,
+			items: [
+				{
+					xtype: 'label',
+					text: 'Session Token (Optional)',
+					forId: 'awsSessionToken'
+				},
+				{
+					id: 'awsSessionToken',
+					xtype: 'textfield',
+					inputType: 'password',
+					anchor: '100%',
+					allowBlank: true,
+					stateful: true,
+					stateId: 'awsSessionToken',
+					stateEvents: ['change'],
+					applyState: function (state) {
+						this.setValue(state.value);
+					},
+					getState: function () {
+						return { value: this.getValue() };
+					}
+				}
+			]
+		},
+		{
 			flex: 0.6,
 			items: [
 				{

--- a/resources/js/scratchpad/awssigner.js
+++ b/resources/js/scratchpad/awssigner.js
@@ -1,10 +1,12 @@
 /*global Ext:false */
 
-function AWSSigner(accessKeyId, secretKey, stsARN) {
-    if (typeof stsARN !== "string" || stsARN.length === 0) {
+function AWSSigner(accessKeyId, secretKey, stsARN, sessionToken) {
+    var notSwitchRole = typeof stsARN !== "string" || stsARN.length === 0
+    var notSessionAuth = typeof sessionToken !== "string" || sessionToken.length === 0
+    if (notSwitchRole) {
         this.accessKeyId = accessKeyId;
         this.secretKey = secretKey;
-        this.sessionToken = null;
+        this.sessionToken = notSessionAuth ? null : sessionToken;
         this.stsARN = null;
     } else {
         this.accessKeyId = null;
@@ -102,8 +104,8 @@ AWSSigner.prototype.generateSignature = function (str) {
 
 AWSV2Signer.prototype = new AWSSigner();
 
-function AWSV2Signer(accessKeyId, secretKey, stsArn) {
-    AWSSigner.call(this, accessKeyId, secretKey, stsArn);
+function AWSV2Signer(accessKeyId, secretKey, stsArn, sessionToken) {
+    AWSSigner.call(this, accessKeyId, secretKey, stsArn, sessionToken);
     this.version = 2;
 }
 


### PR DESCRIPTION
This PR resolves #27.

Support API key authentication with session token.

Changes
* singer can receive aws session token
* Add form fields for session token (optional)

![Screenshot from 2022-03-24 16-44-25](https://user-images.githubusercontent.com/1145948/159870908-1d0db127-0d59-405f-91d0-c4f5ace48e3f.png)
